### PR TITLE
Add npm scripts to run phpunit in wp-env.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /wordpress/
 composer.lock
 package-lock.json
+*.cache

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "watch": "gulp watch",
     "gulp": "gulp",
     "lint": "gulp lint",
-    "gulp:task": "gulp --tasks"
+    "gulp:task": "gulp --tasks",
+	"test": "wp-env run tests-cli ./wp-content/plugins/taro-clockwork-post/vendor/bin/phpunit -c ./wp-content/plugins/taro-clockwork-post/phpunit.xml.dist"
   },
   "repository": {
     "type": "git",
@@ -33,7 +34,7 @@
     "@babel/core": "^7.1.0",
     "@babel/plugin-transform-react-jsx": "^7.0.0",
     "@babel/preset-env": "^7.1.0",
-    "@wordpress/env": "^4.0",
+    "@wordpress/env": "^5.0",
     "@wordpress/eslint-plugin": "^9.0",
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.5",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,7 @@
 	convertWarningsToExceptions="true"
 	>
 	<testsuites>
-		<testsuite>
+		<testsuite name="Plugin Basic Test">
 			<directory prefix="test-" suffix=".php">./tests/</directory>
 			<exclude>./tests/test-sample.php</exclude>
 		</testsuite>


### PR DESCRIPTION
PHPUnit is executable on a docker container. `bash bin/install-wp-test.sh` is not necessary anymore.

```
# Start wp-env
npm start

# Run PHPUnit
npm run test
```