### PR TITLE
Add PHPStan Level 5 static analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         ],
         "fix": [
             "phpcbf --standard=phpcs.ruleset.xml $(find ./ -name '*.php')"
-        ]
+        ],
+        "phpstan": "phpstan analyse --memory-limit=1G"
     },
     "authors": [
         {
@@ -38,7 +39,10 @@
         "wp-coding-standards/wpcs": "^3.0",
         "yoast/phpunit-polyfills": "^1.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-        "wpackagist-plugin/taro-ad-fields": "^1.2"
+        "wpackagist-plugin/taro-ad-fields": "^1.2",
+		"phpstan/phpstan": "^2.1",
+		"szepeviktor/phpstan-wordpress": "^2.0",
+		"php-stubs/wordpress-stubs": "^6.9"
 	},
     "config": {
         "allow-plugins": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,13 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Anonymous function has an unused use \$post_type\.$#'
+			identifier: closure.unusedUse
+			count: 1
+			path: includes/meta-box.php
+
+		-
+			message: '#^Parameter \#2 \$output of function get_post_types expects ''names''\|''objects'', ''OBJECT'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/setting.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,9 @@
+includes:
+    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - phpstan-baseline.neon
+
+parameters:
+    level: 5
+    paths:
+        - taro-clockwork-post.php
+        - includes/


### PR DESCRIPTION
## Summary
- PHPStan Level 5 + WordPress extensions を追加
- 既存エラーは baseline に記録（新規コードのみ Level 5 準拠を要求）
- `composer phpstan` で実行可能

タロスカイ全プラグイン標準化の一環。

🤖 Generated with [Claude Code](https://claude.com/claude-code)