### PR TITLE
Replace bin/build.sh with npm run package in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,19 +24,16 @@ jobs:
           php-version: 7.4
           tools: composer
 
-      - name: Install Composer Dependencies
-        run: composer install --no-dev --prefer-dist
-
       - name: Setup Node.JS
         uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'
 
-      - name: Install npm dependencies
-        run: npm install
-
-      - name: Build Assets
-        run: bash bin/build.sh ${{ github.event.release.tag_name }}
+      - name: Install dependencies and build Assets
+        run: |
+          composer install --no-dev --prefer-dist
+          npm install
+          npm run package
 
       - name: Generate readme.txt
         uses: tarosky/workflows/actions/wp-readme@main


### PR DESCRIPTION
## Summary
- Replace `bash bin/build.sh` with direct `npm run package` command
- Consolidate dependency install + build into a single step

## Test plan
- [ ] Verify deploy workflow runs correctly on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)